### PR TITLE
Adding the fms_diag_object container. (#867)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,8 @@ list(APPEND fms_fortran_src_files
   diag_manager/fms_diag_object.F90
   diag_manager/fms_diag_yaml.F90
   diag_manager/fms_diag_yaml_object.F90
+  diag_manager/fms_diag_dlinked_list.F90
+  diag_manager/fms_diag_object_container.F90
   drifters/cloud_interpolator.F90
   drifters/drifters.F90
   drifters/drifters_comm.F90

--- a/diag_manager/Makefile.am
+++ b/diag_manager/Makefile.am
@@ -31,8 +31,8 @@ noinst_LTLIBRARIES = libdiag_manager.la
 
 # Each convenience library depends on its source.
 libdiag_manager_la_SOURCES = \
-  diag_axis.F90 \
   diag_data.F90 \
+  diag_axis.F90 \
   diag_grid.F90 \
   diag_manager.F90 \
   diag_output.F90 \
@@ -40,7 +40,9 @@ libdiag_manager_la_SOURCES = \
   diag_util.F90 \
   fms_diag_yaml.F90 \
   fms_diag_object.F90 \
-  fms_diag_yaml_object.F90
+  fms_diag_yaml_object.F90 \
+  fms_diag_object_container.F90 \
+  fms_diag_dlinked_list.F90
 
 # Some mods are dependant on other mods in this dir.
 diag_axis_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT)
@@ -49,12 +51,14 @@ diag_util_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) diag_axis_mod.$(FC_MODEXT
                             diag_grid_mod.$(FC_MODEXT)
 diag_table_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) diag_util_mod.$(FC_MODEXT)
 fms_diag_yaml_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) diag_util_mod.$(FC_MODEXT) \
-                                  fms_diag_yaml_object_mod.$(FC_MODEXT)
+                                fms_diag_yaml_object_mod.$(FC_MODEXT)
 fms_diag_object_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) diag_axis_mod.$(FC_MODEXT) \
                                   fms_diag_yaml_object_mod.$(FC_MODEXT)
+fms_diag_object_container_mod.$(FC_MODEXT): fms_diag_object_mod.$(FC_MODEXT) fms_diag_dlinked_list_mod.$(FC_MODEXT)
 diag_manager_mod.$(FC_MODEXT): diag_axis_mod.$(FC_MODEXT) diag_data_mod.$(FC_MODEXT) diag_util_mod.$(FC_MODEXT) \
-	                   diag_output_mod.$(FC_MODEXT) diag_grid_mod.$(FC_MODEXT) diag_table_mod.$(FC_MODEXT) \
-			   fms_diag_object_mod.$(FC_MODEXT) fms_diag_yaml_mod.$(FC_MODEXT)
+                               diag_output_mod.$(FC_MODEXT) diag_grid_mod.$(FC_MODEXT) diag_table_mod.$(FC_MODEXT) \
+                               fms_diag_object_mod.$(FC_MODEXT) fms_diag_yaml_mod.$(FC_MODEXT) \
+                               fms_diag_object_container_mod.$(FC_MODEXT)
 
 # Mod files are built and then installed as headers.
 MODFILES = \
@@ -67,7 +71,10 @@ MODFILES = \
   fms_diag_yaml_object_mod.$(FC_MODEXT) \
   fms_diag_yaml_mod.$(FC_MODEXT) \
   fms_diag_object_mod.$(FC_MODEXT) \
+  fms_diag_dlinked_list_mod.$(FC_MODEXT) \
+  fms_diag_object_container_mod.$(FC_MODEXT) \
   diag_manager_mod.$(FC_MODEXT)
+
 nodist_include_HEADERS = $(MODFILES)
 BUILT_SOURCES = $(MODFILES)
 

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -225,10 +225,14 @@ use platform_mod
   USE diag_table_mod, ONLY: parse_diag_table
   USE diag_output_mod, ONLY: get_diag_global_att, set_diag_global_att
   USE diag_grid_mod, ONLY: diag_grid_init, diag_grid_end
+  USE fms_diag_object_mod, ONLY: fms_diag_object
+  use fms_diag_object_container_mod, ONLY: FmsDiagObjectContainer_t
+
 #ifdef use_yaml
   use fms_diag_yaml_mod, only: diag_yaml_object_init, diag_yaml_object_end
 #endif
   USE fms_diag_object_mod, ONLY: fms_diag_object, diag_object_placeholder
+
   USE constants_mod, ONLY: SECONDS_PER_DAY
 
 #ifdef use_netCDF
@@ -263,6 +267,8 @@ use platform_mod
 #include<file_version.h>
 
   type(time_type) :: Time_end
+
+  TYPE(FmsDiagObjectContainer_t), ALLOCATABLE :: the_diag_object_container
 
   !> @brief Send data over to output fields.
   !!
@@ -428,6 +434,9 @@ CONTAINS
     LOGICAL :: mask_variant1, verbose1
     LOGICAL :: cm_found
     CHARACTER(len=128) :: msg
+    INTEGER :: status_ic !< used to check the status of insert into container.
+    CLASS(fms_diag_object), ALLOCATABLE , TARGET :: diag_obj  !< the diag object that is (to be) registered
+    TYPE(fms_diag_object), POINTER :: diag_obj_ptr => NULL() !< a pointer to the registered diag_object
 
     ! get stdout unit number
     stdout_unit = stdout()
@@ -587,13 +596,23 @@ CONTAINS
     END IF
 
     if (use_modern_diag) then
-            call diag_object_placeholder(1)%register &
-       (module_name, field_name, axes, init_time, &
-       long_name, units, missing_value, Range, mask_variant, standard_name, &
-       do_not_log, err_msg, interp_method, tile_count, area, volume, realm) !(no metadata here)
+      !! Create a diag object, initialize it with the registered data, and insert
+      !! it ino the diag_obj_container singleton.
+
+      allocate( diag_obj )
+      call diag_obj%register (module_name, field_name, axes, init_time, &
+        long_name, units, missing_value, Range, mask_variant, standard_name, &
+        do_not_log, err_msg, interp_method, tile_count, area, volume, realm) !(no metadata here)
+
+      diag_obj_ptr => diag_obj
+      status_ic = the_diag_object_container%insert(diag_obj_ptr%get_id(), diag_obj_ptr)
+      if(status_ic .ne. 0) then
+         print *, "Insertion ERROR for id ", diag_obj_ptr%get_id()
+      endif
     endif
 
   END FUNCTION register_diag_field_array
+
 
   !> @brief Return field index for subsequent call to send_data.
   !! @return field index for subsequent call to send_data.
@@ -3714,6 +3733,9 @@ CONTAINS
             & 'Missing Value', SEP, 'Min Value',      SEP, 'Max Value',    SEP,&
             & 'AXES LIST'
     END IF
+
+    !!Create the diag_object container; Its a singleton in the diag_data mod
+    the_diag_object_container = FmsDiagObjectContainer_t()
 
     module_is_initialized = .TRUE.
     ! create axis_id for scalars here

--- a/diag_manager/fms_diag_dlinked_list.F90
+++ b/diag_manager/fms_diag_dlinked_list.F90
@@ -1,0 +1,323 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+!> @defgroup fms_diag_dlinked_list_mod fms_diag_dlinked_list_mod
+!> @ingroup diag_manager
+!> @brief fms_diag_dlinked_list_mod defines a generic doubly linked
+!! list class and an iterator class for traversing the list.
+!!
+!> @author Miguel Zuniga
+!!
+!! <TT>fms_diag_dlinked_list_mod</TT>  defines a generic doubly linked
+!! list class and an iterator class for traversing the list. It is
+!! generic in the sense that the elements or objects it contains are
+!! "class(*)" objects.  If additional typecheking or psossibly a
+!! slightly different user interface is desired, consider creating
+!! a wrapper or another class with this one for a memeber element and
+!! procedures that are trivially implemeted by using this class.
+!!
+!! This version is roughly a fortran translation of the C++ doubly linked list
+!! class in the book ``Data Structures And Algorithm Analysis in C++", 3rd Edition,
+!! by Mark Allen Weiss.
+
+!> @file
+!> @brief File for @ref fms_diag_dlinked_list_mod
+!> @addtogroup fms_diag_dlinked_list_mod
+!> @{
+MODULE fms_diag_dlinked_list_mod
+  USE fms_mod, ONLY: error_mesg, FATAL, WARNING, NOTE
+  implicit none
+  !!TODO: COnsider setting the access (public,private) to functions, etc.
+  !> The doubly-linked list node type.
+  type, public:: FmsDlListNode_t
+    private
+    class(*), pointer :: data => null()        !< The data pointed to by the node.
+    type(FmsDlListNode_t), pointer :: next => null() !< A pointer to the previous node.
+    type(FmsDlListNode_t), pointer :: prev => null() !< A pointer to the next node.
+  end type FmsDlListNode_t
+
+  !> Linked list iterator
+  type, public :: FmsDllIterator_t
+  private
+    type(FmsDlListNode_t), pointer :: current  !< A pointer to the current node.
+    type(FmsDlListNode_t), pointer :: end      !< A sentinel (non-data) node.
+  contains
+    procedure :: has_data => literator_has_data !< Function returns true is there is data in the iterator.
+    procedure :: next => literator_next !< Function moves the iterator to the next data element.
+    procedure :: get => literator_data !< Function return a pointer to the current data.
+    procedure :: get_current_node_pointer => get_current_node_ptr !< Return  the current node pointer.
+  end type FmsDllIterator_t
+
+  !> The doubly-linked list type. Besides the member functions, see the
+  !! associated iterator class ( FmsDllIterator_t) for traversal, and note that
+  !! the default constructor is overriden with an interface of the same name.
+  type, public :: FmsDlList_t
+  private
+    type(FmsDlListNode_t), pointer :: head !< The sentinal (non-data) head node of the linked list. .
+    type(FmsDlListNode_t), pointer :: tail !< The sentinel (non-data) tail node of the linked list.
+    integer :: the_size               !< The number of data elements in the linked list.
+  contains
+    procedure :: push_back => push_at_back
+    procedure :: pop_back => pop_at_back
+    procedure :: remove => remove_node
+    procedure :: get_literator => get_forward_literator
+    procedure :: size => get_size
+    procedure :: is_empty => is_size_zero
+    procedure :: clear => clear_all
+    final :: destructor
+    procedure  :: insert => insert_data
+
+  end type FmsDlList_t
+
+  interface FmsDlListNode_t
+    module procedure :: node_constructor
+  end interface FmsDlListNode_t
+
+  interface FmsDlList_t
+    module procedure :: linked_list_constructor
+  end interface FmsDlList_t
+
+  interface FmsDllIterator_t
+    module procedure :: literator_constructor
+  end interface FmsDllIterator_t
+
+contains
+
+  !> @brief Insert data d in a new node to be placed in front of the
+  !! target node t_nd.
+  !! @return Returns an iterator that starts with the newly inserted node.
+  function  insert_data( this, t_nd,  d ) result(liter)
+    class(FmsDlList_t), intent(in out) :: this !<The instance of the class that this function is bound to.
+    type(FmsDlListNode_t), pointer, intent (in)  :: t_nd  !< The target node.
+    class(*), target, intent(in)                 :: d     !< The data to insert.
+    class(FmsDllIterator_t), allocatable         :: liter !< A linked list iterator.
+    class(FmsDlListNode_t), pointer :: nd              !< The new node that is to "hold" the data.
+    allocate(nd)
+    nd%data => d
+    !!  Insert nd into list so that list section [prev node <--> target node ] looks like
+    !!  [prev node <--> new nd <--> target node]. The four pointers pointing to and/or
+    !! from "new nd" need to be set. Therefore :
+    !!  a) The new nd's prev needs to be whatever was the targets prev:
+    nd%prev => t_nd%prev
+    !!  b) New node nd's next is obviously the target node:
+    nd%next => t_nd
+    !!  c) the next of the prev node needs to point to the new node nd:
+    t_nd%prev%next => nd
+    !!  d) target node's prev needs to point to the new node :
+    t_nd%prev => nd
+    this%the_size = this%the_size + 1
+    liter = FmsDllIterator_t(nd, this%tail)
+  end function insert_data
+
+  !> @brief Remove Node nd from the linked tree.
+  !! @return Return the iterator that begins with the next node after nd, and ends with
+  !! the list end node. Returns the list iterator if the node cannot be removed.
+  function  remove_node( this, nd ) result( litr)
+    class(FmsDlList_t), intent(in out) :: this !<The instance of the class that this function is bound to.
+    type(FmsDlListNode_t), pointer, intent(in out) :: nd  !< The node to remove from the list.
+    class(FmsDllIterator_t), ALLOCATABLE  :: litr         !< The iterator starting from the node that was
+                                                          !<  following the removed node.
+    !Dont even try to remove the head and tail nodes!
+    if (.not. ( associated (this%head , nd ) .or. &
+      associated (this%tail , nd ) )) THEN
+      litr = FmsDllIterator_t( nd%next, this%tail )
+      nd%prev%next => nd%next
+      nd%next%prev => nd%prev
+      deallocate(nd)
+      this%the_size =  this%the_size - 1
+    else
+      litr = this%get_literator()
+    endif
+  end function remove_node
+
+
+  !> @brief Remove the tail (last data node) of the list.
+  !! @return  Returns an iterator to the remaining list.
+  function pop_at_back (this ) result( liter )
+    class(FmsDlList_t), intent(in out) :: this !<The instance of the class that this function is bound to.
+    class(FmsDllIterator_t) , allocatable :: liter  !< The iterator for the remaining list.
+    !!
+    type(FmsDlListNode_t), pointer :: nd !< The node being removed.
+    if(this%the_size /= 0) then
+      nd => this%tail%prev
+      liter = this%remove( nd )
+    else
+      liter = this%get_literator()
+    endif
+  end function pop_at_back
+
+  !> @brief Push (insert) data at the end of the list
+  !> @return Returns an iterator that starts at the tail of the list.
+  function push_at_back( this, d ) result(litr)
+    class(FmsDlList_t), intent(in out) :: this   !<The instance of the class that this function is bound to.
+    class(*), target, intent(in out) :: d        !< The data to insert.
+    class(FmsDllIterator_t), allocatable :: litr       !< The iterator for the resultant list.
+    litr =  this%insert (this%tail, d)
+  end function push_at_back
+
+  !> @brief Constructor for the node_type
+  !! @return Returns a nully allocated node.
+  function node_constructor () result (nd)
+    type(FmsDlListNode_t), allocatable :: nd  !< The allocated node.
+    allocate(nd)
+    nd%data => null()
+    nd%prev => null()
+    nd%next => null()
+  end function node_constructor
+
+  !> @brief Constructor for the linked list.
+  !! @return Returns a newly allocated linked list instance.
+  function linked_list_constructor () result (ll)
+    type(FmsDlList_t), allocatable :: ll !< The resultant linked list to be reutrned.
+    allocate(ll)
+    allocate(ll%head)
+    allocate(ll%tail)
+    !!print *, 'associated(ll%head) :' , associated(ll%head), &
+    !! ' associated(ll%head) :' , associated(ll%head)
+    ll%head%next => ll%tail
+    ll%tail%prev => ll%head
+    ll%the_size = 0
+  end function linked_list_constructor
+
+  !> @brief The list iterator constructor.
+  !! @return Returns a newly allocated list iterator.
+  function literator_constructor ( fnd, tnd ) result (litr)
+    type (FmsDlListNode_t), pointer  :: fnd
+    !< The sentinal (non-data) "first node" of the iterator will be fnd
+    type (FmsDlListNode_t), pointer  :: tnd
+    !< The sentinal (non-data) "last node" of the iterator will be tnd.
+    type (FmsDllIterator_t), allocatable :: litr  !< The resultant linked list to be reutrned.
+    allocate(litr)
+    litr%current => fnd
+    litr%end => tnd
+  end function literator_constructor
+
+  !> @brief Getter for the size (the number of data elements) of the linked list.
+  !! @return Returns the size of the lined list.
+  function get_size (this) result (sz)
+    class(FmsDlList_t), intent(in out) :: this
+    !<The instance of the class that this function is bound to.
+    integer  :: sz           !< The size (number of data elements)
+    sz = this%the_size
+  end function get_size
+
+!> @brief Determines if the size (number of data elements) of the list is zero.
+!! @return Returns true if there are zero (0) data elements in the list; false otherwise.
+  function is_size_zero (this) result (r)
+    class(FmsDlList_t), intent(in out) :: this
+    !<The instance of the class that this function is bound to.
+    logical :: r !< True iff the size (number of data elements) is zero.
+    if (this%the_size == 0) then
+      r = .true.
+    else
+      r = .false.
+    end if
+  end function is_size_zero
+
+  !> @brief Create and return a new forward iterator for the list.
+  !> @return Returns a forward iterator for the linked list.
+  function get_forward_literator(this) result (litr)
+    class(FmsDlList_t), intent(in) :: this !<The instance of the class that this function is bound to.
+    class(FmsDllIterator_t), ALLOCATABLE :: litr !< The iterator to be returned
+    litr = FmsDllIterator_t( this%head%next, this%tail )
+  end function get_forward_literator
+
+  !> @brief Determine if the iterator has data.
+  !> @return Returns true iff the iterator has data.
+  function literator_has_data( this ) result( r )
+    class(FmsDllIterator_t), intent(in) :: this
+    !<The instance of the class that this function is bound to.
+    logical :: r !< The result true/false.
+    if( associated (this%current, this%end )) then
+      r = .false.
+    else
+      r = .true.
+    end if
+  end function literator_has_data
+
+  !> @brief Move the iterators current data node pointer to the next data node.
+  !! @return Returns a status of 0 if succesful, -1 otherwise.
+  function literator_next( this ) result( status )
+    class(FmsDllIterator_t), intent(in out ) :: this
+    integer :: status !< The returned status. Failure possible is if iterator does not have data.
+    status = -1
+    if(this%has_data() .eqv. .true.) then
+      this%current => this%current%next
+      status = 0
+    endif
+  end function literator_next
+
+  !> @brief Get the current data object pointed to by the iterator.
+  !! function does not allocate or assign the result if
+  !! the user mistakenly called it without data present.
+  !! @return Returns a pointer to the current data.
+  function  literator_data( this ) result( rd )
+    class(FmsDllIterator_t), intent(in) :: this !<The instance of the class that this function is bound to.
+    class(*),  pointer  :: rd !< The current data element of the iterator.
+    rd => null()
+    if (this%has_data() .eqv. .true.) then
+      rd => this%current%data
+    endif
+  end function literator_data
+
+!> @brief Get the current data object pointed to by the iterator.
+  !! function does not allocate or assign the result if
+  !! the user mistakenly called it without data present.
+  !! @return Returns a pointer to the current data.
+  function  get_current_node_ptr( this ) result( pn )
+    class(FmsDllIterator_t), intent(in) :: this !<The instance of the class that this function is bound to.
+    type(FmsDlListNode_t), pointer :: pn        !< The sentinel (non-data) tail node of the linked list.
+    pn  => this%current
+  end function get_current_node_ptr
+
+  !> @brief Iterate over all the nodes, remove them and deallocate the client data
+  !! that the node was holding.
+  subroutine clear_all( this  )
+    class(FmsDlList_t), intent(inout) :: this !<The instance of the class that this function is bound to.
+    type(FmsDlListNode_t), pointer :: nd              !< A pointer to linked list node.
+    class(FmsDllIterator_t), allocatable :: iter      !< A linked list iterator.
+    class(*),  pointer  :: pdata                      !< A pointer to the data.
+    !
+    do while( this% the_size /= 0)
+      nd => this%head%next
+      iter =  this%remove(nd)
+      pdata => iter%get()
+      if (associated(pdata) .eqv. .false.) then
+        call  error_mesg ('doubly_linked_list:clear_all', &
+          'linked list destructor containes unassociated data pointer', &
+          WARNING)
+      else
+        deallocate(pdata)
+      endif
+    end do
+  end subroutine clear_all
+
+  !>  @brief A destructor that deallocates every node and each nodes data element.
+    subroutine destructor(this)
+      type(FmsDlList_t) :: this  !<The instance of the type that this function is bound to.
+      !! Note in the line above we use "type' and not "class" - needed for destructor definitions.
+    call this%clear()
+    deallocate(this%head)
+    deallocate(this%tail)
+  end subroutine destructor
+
+
+end module fms_diag_dlinked_list_mod
+!> @}
+! close documentation grouping

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -4,12 +4,13 @@ module fms_diag_object_mod
 !! \brief Contains routines for the diag_objects
 !!
 !! \description The diag_manager passes an object back and forth between the diag routines and the users.
-!! The procedures of this object and the types are all in this module.  The fms_dag_object is a type 
+!! The procedures of this object and the types are all in this module.  The fms_dag_object is a type
 !! that contains all of the information of the variable.  It is extended by a type that holds the
 !! appropriate buffer for the data for manipulation.
 use diag_data_mod,  only: diag_null
 use diag_data_mod,  only: r8, r4, i8, i4, string, null_type_int
 use diag_data_mod,  only: diag_null, diag_not_found, diag_not_registered, diag_registered_id
+
 use diag_axis_mod,  only: diag_axis_type
 use mpp_mod, only: fatal, note, warning, mpp_error
 use fms_diag_yaml_object_mod, only: diagYamlFiles_type, diagYamlFilesVar_type
@@ -32,7 +33,7 @@ type fms_diag_object
      type (diagYamlFilesVar_type), allocatable, dimension(:) :: diag_field !< info from diag_table
      type (diagYamlFiles_type),     allocatable, dimension(:) :: diag_file  !< info from diag_table
      integer, allocatable, private                    :: diag_id           !< unique id for varable
-     class(FmsNetcdfFile_t), dimension (:), pointer   :: fileob => NULL()  !< A pointer to all of the 
+     class(FmsNetcdfFile_t), dimension (:), pointer   :: fileob => NULL()  !< A pointer to all of the
                                                                            !! file objects for this variable
      character(len=:), allocatable, dimension(:)      :: metadata          !< metedata for the variable
      logical, private                                 :: static            !< true is this is a static var
@@ -41,12 +42,12 @@ type fms_diag_object
      logical, allocatable, private                    :: local             !< If the output is local
      TYPE(time_type), private                         :: init_time         !< The initial time
      integer,          allocatable, private           :: vartype           !< the type of varaible
-     character(len=:), allocatable, private           :: varname           !< the name of the variable     
-     character(len=:), allocatable, private           :: longname          !< longname of the variable     
-     character(len=:), allocatable, private           :: standname         !< standard name of the variable     
+     character(len=:), allocatable, private           :: varname           !< the name of the variable
+     character(len=:), allocatable, private           :: longname          !< longname of the variable
+     character(len=:), allocatable, private           :: standname         !< standard name of the variable
      character(len=:), allocatable, private           :: units             !< the units
      character(len=:), allocatable, private           :: modname           !< the module
-     character(len=:), allocatable, private           :: realm             !< String to set as the value 
+     character(len=:), allocatable, private           :: realm             !< String to set as the value
                                                                            !! to the modeling_realm attribute
      character(len=:), allocatable, private           :: err_msg           !< An error message
      character(len=:), allocatable, private           :: interp_method     !< The interp method to be used
@@ -76,7 +77,7 @@ type fms_diag_object
      procedure :: get_id => fms_diag_get_id
      procedure :: id => fms_diag_get_id
      procedure :: copy => copy_diag_obj
-     procedure :: register => fms_register_diag_field_obj
+     procedure :: register => fms_register_diag_field_obj !! Merely initialize fields.
      procedure :: setID => set_diag_id
      procedure :: is_registered => diag_ob_registered
      procedure :: set_type => set_vartype
@@ -157,7 +158,7 @@ subroutine diag_obj_init(ob)
  end select
 end subroutine diag_obj_init
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!> \description Fills in and allocates (when necessary) the values in the diagnostic object
+!> \Description Fills in and allocates (when necessary) the values in the diagnostic object
 subroutine fms_register_diag_field_obj &
                 !(dobj, modname, varname, axes, time, longname, units, missing_value, metadata)
        (dobj, modname, varname, axes, init_time, &
@@ -195,11 +196,14 @@ subroutine fms_register_diag_field_obj &
 !  TO DO:
 !  dobj%diag_field = get_diag_table_field(trim(varname))
 !  dobj%diag_field = diag_yaml%get_diag_field(
+  !! TODO : Discuss design. Is this a premature return that somehow should
+  !! indicate a warning or failure to the calling function and/or the log files?
 !  if (is_field_type_null(dobj%diag_field)) then
 !     dobj%diag_id = diag_not_found
 !     dobj%vartype = diag_null
 !     return
 !  endif
+
 !> get the optional arguments if included and the diagnostic is in the diag table
   if (present(longname)) then
      allocate(character(len=len(longname)) :: dobj%longname)
@@ -208,7 +212,7 @@ subroutine fms_register_diag_field_obj &
   if (present(standname)) then
      allocate(character(len=len(standname)) :: dobj%standname)
      dobj%standname = trim(standname)
-  endif  
+  endif
   if (present(units)) then
      allocate(character(len=len(units)) :: dobj%units)
      dobj%units = trim(units)
@@ -232,7 +236,7 @@ subroutine fms_register_diag_field_obj &
                      "The missing value passed to register a diagnostic is not a r8, r4, i8, or i4",&
                      FATAL)
     end select
-  else   
+  else
       dobj%missing_value = DIAG_NULL
   endif
 
@@ -240,6 +244,8 @@ subroutine fms_register_diag_field_obj &
 !     write(6,*)"IKIND for "//trim(varname)//" is ",dobj%diag_field%ikind
 !> Set the registered flag to true
  dobj%registered = .true.
+ ! save it in the diag object container.
+
 end subroutine fms_register_diag_field_obj
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !> \brief Sets the diag_id.  This can only be done if a variable is unregistered
@@ -272,7 +278,7 @@ subroutine set_vartype(objin , var)
      class default
           objin%vartype = null_type_int
           call mpp_error("set_vartype", "The variable"//objin%varname//" is not a supported type "// &
-          " r8, r4, i8, i4, or string.", warning) 
+          " r8, r4, i8, i4, or string.", warning)
  end select
 end subroutine set_vartype
 !> \brief Prints to the screen what type the diag variable is
@@ -310,7 +316,7 @@ end subroutine what_is_vartype
 !!MZ Is this a TODO. Many problems:
 !> \brief Registers the object
 subroutine diag_ob_registered(objin , reg)
- class (fms_diag_object)      , intent(inout):: objin 
+ class (fms_diag_object)      , intent(inout):: objin
  logical                      , intent(in)   :: reg !< If registering, this is true
  objin%registered = reg
 end subroutine diag_ob_registered
@@ -330,11 +336,11 @@ select type (objout)
 !     type (diag_fields_type)                           :: diag_field         !< info from diag_table
 !     type (diag_files_type),allocatable, dimension(:)  :: diag_file          !< info from diag_table
 
-     objout%diag_id = objin%diag_id           
+     objout%diag_id = objin%diag_id
 
 !     class (fms_io_obj), allocatable, dimension(:)    :: fms_fileobj        !< fileobjs
      if (allocated(objin%metadata)) objout%metadata = objin%metadata
-     objout%static = objin%static         
+     objout%static = objin%static
      if (allocated(objin%frequency)) objout%frequency = objin%frequency
      if (allocated(objin%varname)) objout%varname = objin%varname
 end select
@@ -344,7 +350,7 @@ end subroutine copy_diag_obj
 integer function fms_diag_get_id (dobj) result(diag_id)
  class(fms_diag_object)     , intent(inout)            :: dobj
 ! character(*)               , intent(in)               :: varname
-!> Check if the diag_object registration has been done 
+!> Check if the diag_object registration has been done
  if (allocated(dobj%registered)) then
          !> Return the diag_id if the variable has been registered
          diag_id = dobj%diag_id

--- a/diag_manager/fms_diag_object_container.F90
+++ b/diag_manager/fms_diag_object_container.F90
@@ -1,0 +1,261 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+!> @defgroup fms_diag_object_container_mod fms_diag_object_container_mod
+!> @ingroup diag_manager
+!> @brief fms_diag_object_container_mod defines a container class and iterator class
+!! for inserting, removing and searching for <TT>fms_diag_object</TT> instances
+!!
+!> @author Miguel Zuniga
+!!
+!! <TT>fms_diag_object_container_mod</TT> defines a container for inserting, removing and
+!! searching for <TT>fms_diag_object</TT> instances. It also defined an iterator for
+!! the data in the container. The value returned by the fms_diag_object function get_id()
+!! is used for search key comparison.
+!!
+!! Most of the functions in class FmsDiagObjectContainer_t are simple wrappers over
+!! those of the underlying  <TT>fms_doubly_linked_list_mod</TT> class. The find/search
+!! are a little more than that, and what FmsDiagObjectContainer_t provides over the
+!! underlying liked  list is the search function, type checking, convenience, and a
+!! fixed user interface defined for the intended use.
+!!
+!> @file
+!> @brief File for @ref fms_diag_object_container_mod
+!> @addtogroup fms_diag_object_container_mod
+!> @{
+MODULE fms_diag_object_container_mod
+   use fms_diag_object_mod, only: fms_diag_object
+   USE fms_mod, ONLY: error_mesg, FATAL, WARNING, NOTE
+
+   !! Since this version is based on the FDS linked list:
+   use fms_diag_dlinked_list_mod, only : FmsDlList_t, FmsDllIterator_t, FmsDlListNode_t
+
+   implicit none
+
+   !> @brief A container of fms_diag_object instances providing insert, remove ,
+   !!  find/search, and size public member functions. Iterator is provided by
+   !!  the associated iterator class (see  dig_obj_iterator class).
+   !!
+   !!  This version does not enforce uniqueness of ID keys (I.e. it is not a set).
+   !!
+   type, public:: FmsDiagObjectContainer_t
+   private
+      TYPE (FmsDlList_t), ALLOCATABLE :: the_linked_list !< This version based on the FDS linked_list.
+   contains
+      procedure :: insert => insert_diag_object
+      procedure :: remove => remove_diag_object
+      procedure :: find   => find_diag_object
+      procedure :: size   => get_num_objects
+      procedure :: iterator  => get_iterator
+      final :: destructor
+   end type FmsDiagObjectContainer_t
+
+
+   !> @brief Iterator used to traverse the objects of the container.
+   type, public :: FmsDiagObjIterator_t
+   private
+      type(FmsDllIterator_t) :: liter !< This version based on the FDS linked_list (and its iterator).
+   contains
+      procedure :: has_data => literator_has_data
+      procedure :: next => literator_next
+      procedure :: get => literator_data
+   end type FmsDiagObjIterator_t
+
+   interface FmsDiagObjectContainer_t
+      module procedure :: diag_object_container_constructor
+   end interface FmsDiagObjectContainer_t
+
+   interface FmsDiagObjIterator_t
+      module procedure :: diag_obj_iterator_constructor
+   end interface FmsDiagObjIterator_t
+
+
+contains
+
+   !> @brief Returns an empty iterator if a diag object with this ID was not found.
+   !! If the diag object was found, return an iterator with the current object being
+   !! the found object, ad the last/anchor being the last/anchor of the container.
+   !! Note that this routine can accept an optional iterator as input, which
+   !! is useful for chaining searches, which may be needed if there are key duplicates.
+   !! @return In iterator that starts from the inserted object.
+   function find_diag_object (this, id , iiter) result (riter)
+     class (FmsDiagObjectContainer_t), intent (in out) :: this
+     !<The instance of the class that this function is bound to.
+      integer , intent (in) :: id   !< The id of the object to find.
+     class(FmsDiagObjIterator_t), intent (in), optional :: iiter
+     !< An (optional) iterator over the searchable set.
+      class(FmsDiagObjIterator_t) , allocatable :: riter !< The resultant iterator to the object.
+      class(fms_diag_object),  pointer:: ptdo  !< A pointer to temporaty diagnostic object
+      integer :: status                        !< A status from iterator operations.
+      !!
+      if(present (iiter)) then
+         riter = iiter
+      else
+         riter = this%iterator() !!An iterator over the entire container
+      endif
+      do while( riter%has_data() .eqv. .true.)
+         ptdo => riter%get()
+         if(id == ptdo%get_id() ) then
+            EXIT
+         end if
+         status = riter%next()
+      end do
+   end function find_diag_object
+
+   !> @brief insert diagnostic object obj with given id.
+   !! Objects are inserted at the back / end of the list
+   !! This version of the container also enforces that the
+   !! objects ID is equal the input id.
+   !! @return A status of -1 if there was an error, and 0 otherwise.
+   function insert_diag_object (this, id, obj) result (status)
+      class (FmsDiagObjectContainer_t), intent (in out) :: this
+      integer,  intent (in) :: id                     !< The id of the object to insert.
+      class(fms_diag_object) , intent (in out) :: obj !< The object to insert
+      integer :: status                               !< The returned status. 0 for success.
+      class(FmsDllIterator_t), allocatable ::  tliter   !< A temporary iterator.
+
+      status = -1
+      if ( id .ne. obj%get_id() ) then
+         !!TODO: log error
+      endif
+      tliter =  this%the_linked_list%push_back( obj )
+      if(tliter%has_data() .eqv. .true. ) then
+         status = 0
+      endif
+   end function
+
+   !> @brief Remove and return the first object in the container with the corresponding id .
+   !! Note that if the client code does not already have a reference to the object being
+   !! removed, then  the client may want to to use procedure find before using procedure remove.
+   !! If procedure find is used, consider calling remove with the iterator returned from find.
+   !! @return In iterator starting from the node that was following the removed node.
+   function remove_diag_object (this, id, iiter ) result (riter)
+     class (FmsDiagObjectContainer_t), intent (in out) :: this
+     !<The instance of the class that this function is bound to.
+     integer , intent (in) :: id !< The id of the object to remove.
+     class(FmsDiagObjIterator_t), intent (in), optional :: iiter
+      !< An (optional) iterator over the searchable set.
+      class(FmsDiagObjIterator_t), allocatable:: riter !< The resultant iterator
+      class(FmsDllIterator_t), allocatable :: temp_liter !< A temporary iterator
+      type(FmsDlListNode_t), pointer :: pn
+      if(present (iiter)) then
+         riter = iiter
+      else
+         riter = this%iterator() !!An iterator over the entire container
+      endif
+      !Find the object in the container.
+      riter = this%find ( id , riter)
+      pn => riter%liter%get_current_node_pointer()
+      temp_liter = this%the_linked_list%remove( pn )
+      riter = FmsDiagObjIterator_t(temp_liter)
+   end function
+
+   !> @brief  Getter for the number of objects help in the container.
+   !! @return Return the number of objects..
+   function get_num_objects (this ) result (sz)
+     class (FmsDiagObjectContainer_t), intent (in out) :: this
+     !< The instance of the class that this function is bound to.
+      integer :: sz                     !< The returned result - the number of objects in container.
+      sz = this%the_linked_list%size()
+   end function
+
+
+   !> @brief Return an iterator for the objects in the container.
+   !! @return An iterator for the objects in the container.
+   function get_iterator (this) result (oliter)
+     class (FmsDiagObjectContainer_t), intent (in) :: this
+     !<The instance of the class that this function is bound to.
+      class(FmsDiagObjIterator_t) , allocatable :: oliter !< The returned iterator.
+      class(FmsDllIterator_t), allocatable ::  temp_iter !< A temporary linked list iterator
+      temp_iter = this%the_linked_list%get_literator()
+      oliter = FmsDiagObjIterator_t( temp_iter )
+   end function
+
+   !> @brief A consructor for a container's iterator.
+   !! @return  An for a container's iterator.
+   function diag_obj_iterator_constructor( iliter ) result (diag_itr)
+     class (FmsDllIterator_t), allocatable :: iliter
+     !< An iterator. Normally the one that the container is based on.
+      class (FmsDiagObjIterator_t), allocatable :: diag_itr !< The returned diag object iterator.
+      allocate(diag_itr)
+      diag_itr%liter = iliter;
+   end function diag_obj_iterator_constructor
+
+   !> @brief The default consructor for the container.
+   !! @return Returns a container.
+   function diag_object_container_constructor () result (doc)
+      type(FmsDiagObjectContainer_t), allocatable :: doc !< The resultant container.
+      allocate(doc)
+      doc%the_linked_list = FmsDlList_t()
+      !! print * , "In DOC constructor"
+   end function diag_object_container_constructor
+
+   !> @brief Determines if there is more data that can be accessed via the iterator.
+   !> @return Returns true iff more data can be accessed via the iterator.
+   function literator_has_data( this ) result( r )
+     class(FmsDiagObjIterator_t), intent(in) :: this
+     !<The instance of the class that this function is bound to.
+      logical :: r                  !< True if this iterator has data.
+      r = this%liter%has_data()
+   end function literator_has_data
+
+   !> @brief Move the iterator to the next object.
+   !! @return Returns a status 0 if sucessful, or -1 if failed.
+   function literator_next( this ) result( status )
+     class(FmsDiagObjIterator_t), intent(in out ) :: this
+     !<The instance of the class that this function is bound to.
+      integer :: status  !< The returned status.
+      status = -1
+      status = this%liter%next()
+   end function literator_next
+
+   !> @brief Get the current data the iterator is pointing to.
+   !! Note the common use case is to call function has_data to decide if
+   !! this function should be called (again).
+   !! @return Returns a pointer to the current data.
+   function  literator_data( this ) result( rdo )
+     class(FmsDiagObjIterator_t), intent(in) :: this
+     !<The instance of the class that this function is bound to.
+      class(fms_diag_object),  pointer :: rdo !< The resultant diagnostic object.
+      class(*),  pointer :: gp !< A eneric typed object in the container.
+
+      rdo => null()
+      gp => this%liter%get()
+      select type(gp)
+       type is (fms_diag_object)  !! "type is", not the (polymorphic) "class is"
+         rdo => gp
+       class default
+         CALL  error_mesg ('diag_object_container:literator_data', &
+            'Data to be accessed via iterator is not of expected type.',FATAL)
+      end select
+   end function literator_data
+
+   !> @brief The destructor for the container.
+   subroutine destructor(this)
+     type(FmsDiagObjectContainer_t) :: this
+     !<The instance of the class that this function is bound to.
+     !Note in the line above we use "type' and not "class" - needed for destructor definitions.
+      deallocate(this%the_linked_list)
+   end subroutine destructor
+
+
+end module fms_diag_object_container_mod
+!> @}
+! close documentation grouping
+

--- a/test_fms/diag_manager/Makefile.am
+++ b/test_fms/diag_manager/Makefile.am
@@ -28,11 +28,14 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(MODDIR)
 LDADD = $(top_builddir)/libFMS/libFMS.la
 
 # Build this test program.
-check_PROGRAMS = test_diag_manager test_diag_manager_time
+check_PROGRAMS = test_diag_manager test_diag_manager_time test_diag_object_container \
+ test_diag_dlinked_list
 
 # This is the source code for the test.
 test_diag_manager_SOURCES = test_diag_manager.F90
 test_diag_manager_time_SOURCES = test_diag_manager_time.F90
+test_diag_object_container_SOURCES = test_diag_object_container.F90
+test_diag_dlinked_list_SOURCES = test_diag_dlinked_list.F90
 
 # Run the test.
 TESTS = test_diag_manager2.sh
@@ -40,4 +43,5 @@ TESTS = test_diag_manager2.sh
 # Copy over other needed files to the srcdir
 EXTRA_DIST = input.nml_base diagTables test_diag_manager2.sh
 
+# Clean up
 CLEANFILES = input.nml *.nc *.out diag_table

--- a/test_fms/diag_manager/test_diag_dlinked_list.F90
+++ b/test_fms/diag_manager/test_diag_dlinked_list.F90
@@ -1,0 +1,238 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+!! <TT>fms_diag_dlinked_list_mod</TT>  defines a generic doubly linked
+!! list class  and an associated iterator class  for traversing the list. It
+!! is generic in the sense that the elements or objects it contains are
+!! "class(*)" objects. Note the public interface functions and the lack
+!! of a search (or find) function as per the definition of a linked list.
+!! If a search function, additional type cheeking,  or possibly a
+!! slightly different user interface is desired, then consider creating
+!! another iterator and another wrapper, or another class with this one for
+!! a member element and procedures that are trivially implemented by using
+!! this class. (See, for example, class FmsDiagObjectContainer_t and its
+!! associated iterator.
+!!
+!! This version is roughly a Fortran translation of the C++ doubly linked list
+!! class in the book ``Data Structures And Algorithm Analysis in C++",
+!! 3rd Edition, by Mark Allen Weiss.
+program test_diag_dlinked_list
+   use mpp_mod, only: mpp_init, mpp_exit, mpp_error, FATAL, WARNING
+   use mpp_mod, only : mpp_set_stack_size, mpp_init_test_requests_allocated
+   use mpp_io_mod, only: mpp_io_init
+
+   use fms_diag_object_mod, only : fms_diag_object
+   use fms_diag_dlinked_list_mod, only : FmsDlList_t, FmsDllIterator_t
+
+   implicit  none
+
+   !> @brief  This class is the type for the data to insert in the linked list.
+   type TestDummy_t
+      integer :: id  = 0
+      character(len=20) :: name
+   end type TestDummy_t
+
+   !!
+   type (FmsDlList_t), allocatable :: list !< Instance of the linked list
+   class(FmsDllIterator_t), allocatable :: iter !< An iterator for the list
+   type (TestDummy_t), pointer::   p_td_obj     !< A pointer to a test_dummy object
+   class(*), pointer :: p_obj                   !< A pointer to a class(*) object
+   integer, parameter :: num_objs = 40          !< Total number of objects tested
+   integer ::  full_id_sum                      !< Sum of all the possible object id values
+   integer :: sum                               !< Temp sum of vaalues of id sets
+   !!
+   integer :: ierr                              !< An error flag
+   logical :: test_passed                       !< Flag indicating if the test_passed
+   !! These fields below used to initialize diag object data. TBD
+   integer :: id
+   character(:), allocatable :: mname, mname_pre
+   !!
+
+
+   test_passed = .true.  !! will be set to false if there are any issues.
+
+   call mpp_init(mpp_init_test_requests_allocated)
+   call mpp_io_init()
+   call mpp_set_stack_size(145746)
+
+   !! Ids will initially be from 1 to num_objs, so :
+   full_id_sum = (num_objs * (num_objs + 1)) / 2
+
+   !!Create the list
+   list = FmsDlList_t()
+
+   if( list%size() /= 0) then
+      test_passed = .false.
+      call mpp_error(FATAL, "list incorrect size. Expected 0 at start")
+   endif
+   mname_pre = "ATM"
+
+  !! Initialize num_objs objects and insert into list one at a time.
+  !! The loop iterator is same as id - created in order to facilitate
+   !! some tests.
+   do id = 1, num_objs
+      !!Allocate on heap another test dummy object :
+      allocate (p_td_obj)
+      !! And set some of its dummy data :
+      call combine_str_int(mname_pre, id, mname)
+      p_td_obj%id = id
+      p_td_obj%name = mname
+      !! And have the "Char(*) pointer also point to it:
+      p_obj => p_td_obj
+
+      !! Test insertion the common way :
+      iter = list%push_back( p_obj)
+      if(iter%has_data() .eqv. .false. ) then
+         test_passed = .false.
+         call mpp_error(FATAL, "List push_back error.")
+      endif
+
+   enddo
+
+   if( list%size() /= num_objs) then
+      test_passed = .false.
+      call mpp_error(FATAL, "List has incorrect size after inserts.")
+   endif
+
+
+   !! Test iteration over the entire list :
+   sum = 0
+   sum = sum_ids_in_list ( list )
+
+   if( sum  /=  full_id_sum) then
+      test_passed = .false.
+      call mpp_error(FATAL, "Id sums via iteration over the list objects is not as expected")
+   endif
+
+   if( list%size() /= num_objs) then
+      test_passed = .false.
+      call mpp_error(FATAL, "The list size is not as expected post inserts.")
+   endif
+
+   !! Test a removal from the back (id should be num_objs)
+   p_obj => find_back_of_list( list)
+   iter = list%pop_back()
+   !! Note the client is resposible for managing memory of anything he explicitly
+   !! removes from the list:
+   deallocate(p_obj)
+   sum = sum_ids_in_list ( list )
+   if( sum  /=  full_id_sum - num_objs ) then
+      test_passed = .false.
+      call mpp_error(FATAL, "Id sums via iteration over the list objects is not as expected")
+   endif
+
+   !! Repeat - test removal from the back of list (should be (num_objs -1)).
+   p_obj => find_back_of_list( list)
+   iter = list%pop_back()
+   !! Note the client is resposible for managing memory of anything he explicitly
+   !! removes from the list:
+   deallocate(p_obj)
+   sum = sum_ids_in_list ( list )
+   if( sum  /=  (full_id_sum - num_objs - (num_objs -1) )) then
+      test_passed = .false.
+      call mpp_error(FATAL, "Id sums via iteration over the list objects is not as expected")
+   endif
+
+   call list%clear()
+   if( list%size() /= 0) then
+      test_passed = .false.
+      call mpp_error(FATAL, "List is incorrect size after clearing.")
+   endif
+
+   write (6,*) "Finishing diag_dlinked_list tests."
+
+   !! the list has a finalize/destructor which will deallocate data that is still it list.
+   !! equivalent to calling list%clear() as above.
+   deallocate(list)
+
+   call MPI_finalize(ierr)
+
+CONTAINS
+
+
+
+   !> @brief Cast the "class(*) input data to the expected type.
+   function  get_typed_data( data_in  ) result( rdo )
+      class(*), intent(in), pointer :: data_in !< An input pointer to the class(*) object.
+      class(TestDummy_t),  pointer :: rdo !< The resultant pointer to the expected underlying object type.
+      rdo => null()
+
+      select type(data_in)
+       type is (TestDummy_t)  !! "type is", not the (polymorphic) "class is"
+         rdo => data_in
+       class default
+         call mpp_error(FATAL, "Data to access is not of expected type.",FATAL)
+      end select
+   end function get_typed_data
+
+   !> Calcualte the sum of the ids.
+   !! Exercises iteration over the list.
+   function sum_ids_in_list (list) result (rsum)
+      type (FmsDlList_t), allocatable :: list !< The linked list instance
+      integer  :: rsum                        !< The resultant sum of ids
+      class(FmsDllIterator_t), allocatable :: iter !< An iterator over the list
+      type (TestDummy_t), pointer::   p_td_obj     !< A pointer to a test_dummy object
+      class(*), pointer :: p_obj                   !< A pointer to a class(*) object
+      integer :: ic_status                         !< A list insertion status.
+      !!
+      rsum = 0
+      iter = list%get_literator()
+      do while( iter%has_data() .eqv. .true.)
+         p_obj => iter%get()
+         p_td_obj => get_typed_data (p_obj )
+         id =  p_td_obj%id
+         rsum = rsum + id
+         ic_status = iter%next()
+      end do
+   end function sum_ids_in_list
+
+  !> Calcualate the sum of the ids. This also is a kind of search function,
+   !! so if the provided wrapper is not used, you have to write your own.
+   !! @return a pointer the object at the end of the list, or null if none
+   function find_back_of_list (list) result (p_rdo)
+    type (FmsDlList_t), allocatable :: list !< The linked list instance
+    class(TestDummy_t),  pointer :: p_rdo !< The resultant back of list,
+    class(FmsDllIterator_t), allocatable :: iter !< An iterator over the list
+    class(*), pointer :: p_obj                   !< A pointer to a class(*) object
+    integer :: ic_status                         !< A list insertion status.
+    !!
+    p_rdo => null()
+    iter = list%get_literator()
+    do while( iter%has_data() .eqv. .true.)
+       p_obj => iter%get()
+       p_rdo => get_typed_data (p_obj )
+       ic_status = iter%next()
+    end do
+ end function find_back_of_list
+
+ subroutine combine_str_int (str, num, rs)
+    character(:), allocatable, intent (in):: str
+    integer ,    intent (in) :: num
+    character(:), allocatable, intent (out) :: rs
+    character(len_trim(str) + 8) :: tmp
+
+    write (tmp, "(A4,I4)") str,num
+    tmp = trim(tmp)
+    rs = tmp
+ end subroutine combine_str_int
+
+
+end program test_diag_dlinked_list
+
+

--- a/test_fms/diag_manager/test_diag_manager2.sh
+++ b/test_fms/diag_manager/test_diag_manager2.sh
@@ -64,6 +64,7 @@ setup_test()
 
 }
 
+
 rm -f input.nml diag_table
 setup_test 1 "Test 1: Data array is too large in x and y direction"
 setup_test 2 "Test 2: Data array is too large in x direction"
@@ -100,3 +101,16 @@ rm -f input.nml diag_table
 touch input.nml
 cp $top_srcdir/test_fms/diag_manager/diagTables/diag_table_25 diag_table
 run_test test_diag_manager_time 1
+
+echo "Test container"
+rm -f input.nml diag_table
+touch input.nml
+cp $top_srcdir/test_fms/diag_manager/diagTables/diag_table_25 diag_table
+run_test test_diag_object_container 1
+
+
+echo "Test linked list "
+rm -f input.nml diag_table
+touch input.nml
+cp $top_srcdir/test_fms/diag_manager/diagTables/diag_table_25 diag_table
+run_test test_diag_dlinked_list 1

--- a/test_fms/diag_manager/test_diag_object_container.F90
+++ b/test_fms/diag_manager/test_diag_object_container.F90
@@ -1,0 +1,237 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+!> @brief  This programs tests  public member functions of the
+!!  FmsDiagObjectContainer_t and FmsDiagObjIterator_t. As these two classes
+!!  are largely wrappers to their underlying classes, it is also
+!!  testing the underlying container and iterator classes. The container
+!!  functions being tested are insert, remove, and size. The use of the iterators
+!!  is also being tested.
+program test_diag_obj_container
+  use mpp_mod, only: mpp_init, mpp_exit, mpp_error, FATAL, WARNING
+  use mpp_mod, only : mpp_set_stack_size, mpp_init_test_requests_allocated
+  use mpp_io_mod, only: mpp_io_init
+
+  use fms_diag_object_mod, only : fms_diag_object
+  use fms_diag_object_container_mod, only : FmsDiagObjectContainer_t, FmsDiagObjIterator_t
+  USE time_manager_mod, ONLY: time_type
+
+  implicit  none
+  !!
+  type (FmsDiagObjectContainer_t), allocatable :: container !< Instance of the container
+  class(FmsDiagObjIterator_t), allocatable :: iter          !< An iterator for the container
+  type (fms_diag_object), allocatable , target ::  obj_vec(:)     !< A vector of objects
+  type (fms_diag_object), pointer::   pobj                        !< A pointer to an object
+  integer, parameter :: num_objs = 10                             !< Total number of objects tested
+  integer ::  full_id_sum                                         !< Sum of all the possible object id values
+  integer :: sum                                                  !< Temp sum of vaalues of id sets
+  !!
+  integer :: ic_status                                            !< A status flag returned from container functions
+  integer :: ierr                                                 !< An error flag
+  !!
+  logical :: test_passed                                          !< Flag indicating if the test_passed
+  !! These fields below used to initialize diag object data. TBD
+  integer :: id
+  integer, dimension(2) :: axes
+  TYPE(time_type)  :: init_time
+  !!type (diag_fields_type)  :: diag_field
+  character(:), allocatable :: mname, vname, mname_pre, vname_pre
+  !!
+
+
+  test_passed = .true.  !! will be set to false if there are any issues.
+
+  call mpp_init(mpp_init_test_requests_allocated)
+  call mpp_io_init()
+  call mpp_set_stack_size(145746)
+
+  !! Ids will initially be from 1 to num_objs, so :
+  full_id_sum = (num_objs * (num_objs + 1)) / 2
+
+  !!Create the container
+  container = FmsDiagObjectContainer_t()
+  !!In diag_manager, one module level container may be used instead of a local one like above.
+
+
+  !! Allocate some test objects.
+  !! NOTE: normally objects will be allocated one at a time with a stament like:
+  !!   allocate(pobj, source = fms_diag_object(argument list ))
+  !! or via constructor like :
+  !!   pobj => fms_diag_object(argument list )
+  !! Once the object ID is set, it should be inserted into the container and then the
+  !!   container will be considered the manager of that object and its memory (unless the object is removed).
+  !! Since type fms_diag_obj doesn't have a proper constructor yet, well be lazy by making array of objects
+  !! ( normal fixed size array the thing whose use we are replacing to begin with ) and consider these particular
+  !! objects to not be managed by the container.
+  allocate(obj_vec(num_objs))
+
+  !! Initialize each object and isnert into container one at a time.
+
+  if( container%size() /= 0) then
+    test_passed = .false.
+    call mpp_error(FATAL, "Container incorrect size. Expected 0 at start")
+  endif
+  mname_pre = "ATM"
+  vname_pre = "xvar"
+  do id = 1, num_objs
+    call combine_str_int(mname_pre, id, mname)
+    call combine_str_int(vname_pre, id, vname )
+
+    pobj => obj_vec( id ) !!Note use of pointer to obj.
+    call pobj%setID(id)
+
+    call pobj%register ("test_mod", vname, axes, init_time, "a_long_name")
+
+    !!Insert object into the container.
+    ic_status = container%insert(pobj%get_id(), pobj)
+    if(ic_status .ne. 0)then
+      test_passed = .false.
+      call mpp_error(FATAL, "Container Insertion error.")
+    endif
+  enddo
+
+  if( container%size() /= num_objs) then
+    test_passed = .false.
+    call mpp_error(FATAL, "Container has incorrect size after inserts.")
+  endif
+
+  !!Search the container for a an object of specified key
+  iter =  container%find(123)
+  if ( iter%has_data() .eqv. .true. ) then
+    test_passed = .false.
+    call mpp_error(FATAL, "Found in container unexpected object of id=123")
+  endif
+
+  !!Again, search the container for a an object of specified key
+  iter = container%find(4)
+  if (iter%has_data() .neqv. .true. ) then
+    test_passed = .false.
+    call mpp_error(FATAL, "Did not find expected container object of id=4")
+  endif
+
+  !! Iterate over all the objects in the container;
+  sum = 0
+  iter = container%iterator()
+  do while( iter%has_data() .eqv. .true.)
+      pobj => iter%get()  !!Note use of pointer and pointer assignment is preferred.
+      id =  pobj%get_id( )
+      !! vname =  pobj%get_varname()  !! print ...
+      sum = sum + id
+      ic_status = iter%next()
+  end do
+
+  if( sum  /=  full_id_sum) then
+    test_passed = .false.
+    call mpp_error(FATAL, "Id sums via iteration over the container objects is not as expected")
+  endif
+
+  if( container%size() /= num_objs) then
+    test_passed = .false.
+    call mpp_error(FATAL, "The container size is not as expected post inserts.")
+  endif
+
+
+  !! Test a removal ****
+  iter = container%iterator()
+  iter  = container%remove( 4, iter )
+  iter  = container%find(4)
+  !! Verify  the removal , part 1:
+  if (  iter%has_data() .eqv. .true.) then
+    test_passed = .false.
+    call mpp_error(FATAL, "Found object of id = 4 after removing it")
+  endif
+   !! Verify  the removal , part 2 :
+  if (container%size() /= (num_objs - 1)) then
+     test_passed = .false.
+    call mpp_error(FATAL,"The_container%size() \= num_obj -1 after a removal ")
+  endif
+
+   !! Verify  the removal , part 3 :
+   !! Iterate over all the objects in the container AFTER the removal of id=4 object;
+  sum = 0
+  iter = container%iterator()
+  do while( iter%has_data() .eqv. .true.)
+      pobj => iter%get()  !!Note use of pointer and pointer assignment is preferred.
+      id =  pobj%get_id( )
+      !! vname =  pobj%get_varname()  !! print ...
+      sum = sum + id
+      ic_status = iter%next()
+  end do
+  if( sum  /=  full_id_sum - 4) then
+    test_passed = .false.
+    call mpp_error(FATAL, "Container incorrect id sums post removal of 4")
+  endif
+  !! End test a removal ****
+
+  !! Test find and access object in the container
+  iter = container%find(7)
+  if (iter%has_data() .neqv. .true. ) then
+    test_passed = .false.
+    call mpp_error(FATAL, "Container did not find object of id=7")
+  endif
+  !! Check the find results more :
+  pobj => iter%get()
+  if(pobj%get_id() /=  7) then
+    test_passed = .false.
+    call mpp_error(FATAL," Id of returned object was not 7 ")
+  endif
+  !!TODO further access tests.
+
+
+  !! Manually clear out the container.
+  !! NOTE: In normal use this is NOT PERFORMED since with its finalize function, the  container
+  !! deallocates all pointers and data it manages. However, the client needs to take care of
+  !! the diag objects the client has decided that the container should not manage.
+  !! In this wierd test case, all the diag objects were originally from a vector (a container itself!)
+  !! and not allocated on the heap one at a time, so this step is needed before program completion.
+  do id = 1, num_objs
+    iter  = container%find(id)
+    if (  iter%has_data() .eqv. .true.) then
+      iter  = container%remove( id, iter )
+    endif
+  end do
+
+  if( container%size() /= 0) then
+    test_passed = .false.
+    call mpp_error(FATAL, "Container is incorrect size after clearing.")
+  endif
+
+  write (6,*) "Finishing diag_obj_container tests."
+
+  !! the container has a finalize/destructor which will
+deallocate(container)
+
+call MPI_finalize(ierr)
+
+CONTAINS
+
+subroutine combine_str_int (str, num, rs)
+  character(:), allocatable, intent (in):: str
+  integer ,    intent (in) :: num
+  character(:), allocatable, intent (out) :: rs
+  character(len_trim(str) + 8) :: tmp
+
+  write (tmp, "(A4,I4)") str,num
+  tmp = trim(tmp)
+  rs = tmp
+end subroutine combine_str_int
+
+end program test_diag_obj_container
+
+


### PR DESCRIPTION
* Initial commit of the fms_diag_object_container. Includes the underlying
linked_list library, some changes to diag_manger to initialize the container
and to use the container upon field registration, related Makefile.am changes.

* Modified diag object iterator to fix casting compilation error on CI system.

* Initial modificationss in response to a review by Tom Robinsom
on  12/7/01. Mostly documentation, logging, and type name improvements.

* Experimenting with documentation annotations.

* Added test of fms_diag_object_container class. Further changes to follow convention
and documentation.

* Corrected script calling unit test. Added todo in fms_diag_yaml.F90.

* Cleaned up test of container.

* Addded a "TODO:" to fms_diag_yaml.F90, function is filed type null.

* Modified new files and unit test for further compliance with coding standards

* Renamed the linked list mod. Corrected CMakeList.txtx and a Makefile.am.

* Renamed linked list mod.  Changed a Makefile.am.

* Fixed CMakeLists.txt.

* Mods to CMakeLIst.txt. Includes adding parser dir files.

* Fixing typo in CMakeLists.txt

* Many comments and documentation chages based on Tom R's 2nd review.

* Adds annotations @addtogroup and @{ to the diag object container mod and the linked list mod.

* Added comments for the "this" variable. Nods to use "!<" for var comments.

* Further doxygen related improvements. Some improvements on on calss access (private/public) lables.

* Five chages of list node instance declarations from class to node to
compile on Intel.

* One change from type to class for an interator instance. Some comment updates.

* Added test_diag_dlinked_list.F90. Modified memeber data/access in several
in several types. Improved several comments.

* Improved or added several comments.

* Removed vs code related files.

* Removing extraneous return statement in test_diag_dlinked_list.F90.

* Improved test_diag_dlinked_list.F90, both code and comments.

* Removed duplicate yaml_parser.F90 from CMakeLists.txt.

* Incorporates changes based on Tom R's latest review.

* Includes some doxygen related changes requested by Ryan M.

**Description**
Include a summary of the change and which issue is fixed. Please also include
relevant motivation and context. List any dependencies that are required for
this change.

Fixes # (issue)

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

